### PR TITLE
#72: Allow 3 lowercase letters as language code

### DIFF
--- a/src/main/scala/no/ndla/imageapi/model/Language.scala
+++ b/src/main/scala/no/ndla/imageapi/model/Language.scala
@@ -11,21 +11,21 @@ import com.sksamuel.elastic4s.analyzers._
 import no.ndla.imageapi.model.domain.LanguageField
 
 object Language {
-  val DefaultLanguage = "nb"
+  val DefaultLanguage = "eng"
   val UnknownLanguage = "unknown"
   val AllLanguages = "all"
   val NoLanguage = ""
 
   val languageAnalyzers = Seq(
-    LanguageAnalyzer(DefaultLanguage, NorwegianLanguageAnalyzer),
-    LanguageAnalyzer("nn", NorwegianLanguageAnalyzer),
-    LanguageAnalyzer("en", EnglishLanguageAnalyzer),
-    LanguageAnalyzer("fr", FrenchLanguageAnalyzer),
-    LanguageAnalyzer("de", GermanLanguageAnalyzer),
-    LanguageAnalyzer("es", SpanishLanguageAnalyzer),
-    LanguageAnalyzer("se", StandardAnalyzer), // SAMI
-    LanguageAnalyzer("zh", ChineseLanguageAnalyzer),
-    LanguageAnalyzer(UnknownLanguage, NorwegianLanguageAnalyzer)
+    LanguageAnalyzer(DefaultLanguage, EnglishLanguageAnalyzer),
+    LanguageAnalyzer("nob", NorwegianLanguageAnalyzer),
+    LanguageAnalyzer("eng", EnglishLanguageAnalyzer),
+    LanguageAnalyzer("fra", FrenchLanguageAnalyzer),
+    LanguageAnalyzer("deu", GermanLanguageAnalyzer),
+    LanguageAnalyzer("spa", SpanishLanguageAnalyzer),
+    LanguageAnalyzer("sme", StandardAnalyzer), // SAMI
+    LanguageAnalyzer("zho", ChineseLanguageAnalyzer),
+    LanguageAnalyzer(UnknownLanguage, EnglishLanguageAnalyzer)
   )
 
   val supportedLanguages = languageAnalyzers.map(_.lang)

--- a/src/main/scala/no/ndla/imageapi/service/ValidationService.scala
+++ b/src/main/scala/no/ndla/imageapi/service/ValidationService.scala
@@ -102,7 +102,7 @@ trait ValidationService {
     }
 
     private def languageCodeIsValid(languageCode: String): Boolean = {
-      val allLowerCase = languageCode.partition(_.isLower)._2.isEmpty
+      val allLowerCase = languageCode.forall(_.isLower)
       val lengthIsOk = languageCode.length == 3
       allLowerCase && lengthIsOk
     }

--- a/src/main/scala/no/ndla/imageapi/service/ValidationService.scala
+++ b/src/main/scala/no/ndla/imageapi/service/ValidationService.scala
@@ -94,15 +94,19 @@ trait ValidationService {
     }
 
     private def validateLanguage(fieldPath: String, languageCode: String): Option[ValidationMessage] = {
-      if (languageCodeSupported6391(languageCode)) {
+      if (languageCodeIsValid(languageCode)) {
         None
       } else {
         Some(ValidationMessage(fieldPath, s"Language '$languageCode' is not a supported value."))
       }
     }
 
-    private def languageCodeSupported6391(languageCode: String): Boolean =
-      get6391CodeFor6392CodeMappings.exists(_._2 == languageCode)
+    private def languageCodeIsValid(languageCode: String): Boolean = {
+      val allLowerCase = languageCode.filter(_.isUpper).isEmpty
+      val lengthIsOk = languageCode.length == 3
+      allLowerCase && lengthIsOk
+    }
+
 
   }
 }

--- a/src/main/scala/no/ndla/imageapi/service/ValidationService.scala
+++ b/src/main/scala/no/ndla/imageapi/service/ValidationService.scala
@@ -102,7 +102,7 @@ trait ValidationService {
     }
 
     private def languageCodeIsValid(languageCode: String): Boolean = {
-      val allLowerCase = languageCode.filter(_.isUpper).isEmpty
+      val allLowerCase = languageCode.partition(_.isLower)._2.isEmpty
       val lengthIsOk = languageCode.length == 3
       allLowerCase && lengthIsOk
     }

--- a/src/test/scala/no/ndla/imageapi/TestData.scala
+++ b/src/test/scala/no/ndla/imageapi/TestData.scala
@@ -25,40 +25,40 @@ object TestData {
 
   val ByNcSa = License("by-nc-sa", "Creative Commons Attribution-NonCommercial-ShareAlike 2.0 Generic", Some("https://creativecommons.org/licenses/by-nc-sa/2.0/"))
 
-  val elg = ImageMetaInformation(Some(1), List(ImageTitle("Elg i busk", "nb")),List(ImageAltText("Elg i busk", "nb")),
+  val elg = ImageMetaInformation(Some(1), List(ImageTitle("Elg i busk", "nob")),List(ImageAltText("Elg i busk", "nob")),
     "Elg.jpg", 2865539, "image/jpeg",
     Copyright(ByNcSa, "http://www.scanpix.no", List(Author("Fotograf", "Test Testesen"))),
-    List(ImageTag(List("rovdyr", "elg"), "nb")), List(ImageCaption("Elg i busk", "nb")), "ndla124", updated())
+    List(ImageTag(List("rovdyr", "elg"), "nob")), List(ImageCaption("Elg i busk", "nob")), "ndla124", updated())
 
-  val bjorn = ImageMetaInformation(Some(2), List(ImageTitle("Bjørn i busk", "nb")),List(ImageAltText("Elg i busk", "nb")),
+  val bjorn = ImageMetaInformation(Some(2), List(ImageTitle("Bjørn i busk", "nob")),List(ImageAltText("Elg i busk", "nob")),
     "Bjørn.jpg", 141134, "image/jpeg",
     Copyright(ByNcSa, "http://www.scanpix.no", List(Author("Fotograf", "Test Testesen"))),
-    List(ImageTag(List("rovdyr", "bjørn"), "nb")), List(ImageCaption("Bjørn i busk", "nb")), "ndla124", updated())
+    List(ImageTag(List("rovdyr", "bjørn"), "nob")), List(ImageCaption("Bjørn i busk", "nob")), "ndla124", updated())
 
-  val jerv = ImageMetaInformation(Some(3), List(ImageTitle("Jerv på stein", "nb")),List(ImageAltText("Elg i busk", "nb")),
+  val jerv = ImageMetaInformation(Some(3), List(ImageTitle("Jerv på stein", "nob")),List(ImageAltText("Elg i busk", "nob")),
     "Jerv.jpg", 39061, "image/jpeg",
     Copyright(ByNcSa, "http://www.scanpix.no", List(Author("Fotograf", "Test Testesen"))),
-    List(ImageTag(List("rovdyr", "jerv"), "nb")), List(ImageCaption("Jerv på stein", "nb")), "ndla124", updated())
+    List(ImageTag(List("rovdyr", "jerv"), "nob")), List(ImageCaption("Jerv på stein", "nob")), "ndla124", updated())
 
-  val mink = ImageMetaInformation(Some(4), List(ImageTitle("Overrasket mink", "nb")),List(ImageAltText("Elg i busk", "nb")),
+  val mink = ImageMetaInformation(Some(4), List(ImageTitle("Overrasket mink", "nob")),List(ImageAltText("Elg i busk", "nob")),
     "Mink.jpg", 102559, "image/jpeg",
     Copyright(ByNcSa, "http://www.scanpix.no", List(Author("Fotograf", "Test Testesen"))),
-    List(ImageTag(List("rovdyr", "mink"), "nb")), List(ImageCaption("Overrasket mink", "nb")), "ndla124", updated())
+    List(ImageTag(List("rovdyr", "mink"), "nob")), List(ImageCaption("Overrasket mink", "nob")), "ndla124", updated())
 
-  val rein = ImageMetaInformation(Some(5), List(ImageTitle("Rein har fanget rødtopp", "nb")),List(ImageAltText("Elg i busk", "nb")),
+  val rein = ImageMetaInformation(Some(5), List(ImageTitle("Rein har fanget rødtopp", "nob")),List(ImageAltText("Elg i busk", "nob")),
     "Rein.jpg", 504911, "image/jpeg",
     Copyright(ByNcSa, "http://www.scanpix.no", List(Author("Fotograf", "Test Testesen"))),
-    List(ImageTag(List("rovdyr", "rein", "jakt"), "nb")), List(ImageCaption("Rein har fanget rødtopp", "nb")), "ndla124", updated())
+    List(ImageTag(List("rovdyr", "rein", "jakt"), "nob")), List(ImageCaption("Rein har fanget rødtopp", "nob")), "ndla124", updated())
 
-  val nonexisting = ImageMetaInformation(Some(6), List(ImageTitle("Krokodille på krok", "nb")),List(ImageAltText("Elg i busk", "nb")),
+  val nonexisting = ImageMetaInformation(Some(6), List(ImageTitle("Krokodille på krok", "nob")),List(ImageAltText("Elg i busk", "nob")),
     "Krokodille.jpg", 2865539, "image/jpeg",
     Copyright(ByNcSa, "http://www.scanpix.no", List(Author("Fotograf", "Test Testesen"))),
-    List(ImageTag(List("rovdyr", "krokodille"), "nb")), List(ImageCaption("Krokodille på krok", "nb")), "ndla124", updated())
+    List(ImageTag(List("rovdyr", "krokodille"), "nob")), List(ImageCaption("Krokodille på krok", "nob")), "ndla124", updated())
 
-  val nonexistingWithoutThumb = ImageMetaInformation(Some(6), List(ImageTitle("Bison på sletten", "nb")),List(ImageAltText("Elg i busk", "nb")),
+  val nonexistingWithoutThumb = ImageMetaInformation(Some(6), List(ImageTitle("Bison på sletten", "nob")),List(ImageAltText("Elg i busk", "nob")),
     "Bison.jpg", 2865539, "image/jpeg",
     Copyright(ByNcSa, "http://www.scanpix.no", List(Author("Fotograf", "Test Testesen"))),
-    List(ImageTag(List("bison"), "nb")), List(ImageCaption("Bison på sletten", "nb")), "ndla124", updated())
+    List(ImageTag(List("bison"), "nob")), List(ImageCaption("Bison på sletten", "nob")), "ndla124", updated())
 
   val testdata = List(elg, bjorn, jerv, mink, rein)
 

--- a/src/test/scala/no/ndla/imageapi/service/ValidationServiceTest.scala
+++ b/src/test/scala/no/ndla/imageapi/service/ValidationServiceTest.scala
@@ -170,7 +170,7 @@ class ValidationServiceTest extends UnitSuite with TestEnvironment {
 
   test("languageCodeIsValid requires 3 lowercase letters") {
     val results = for {
-      language <- Seq("", "a", "no", "enG", "ENG", "nOB", "nobb")
+      language <- Seq("", "a", "no", "enG", "ENG", "nOB", "nobb", "---")
       imageMeta = sampleImageMeta.copy(alttexts=Seq(ImageAltText("alt text", language)))
     } yield (language, validationService.validate(imageMeta).isSuccess)
     results.foreach{case (lang, success) => withClue(s"Language '$lang' should not be accepted.") { success should be (false)} }

--- a/src/test/scala/no/ndla/imageapi/service/ValidationServiceTest.scala
+++ b/src/test/scala/no/ndla/imageapi/service/ValidationServiceTest.scala
@@ -46,7 +46,7 @@ class ValidationServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("validate returns a validation error if title contains html") {
-    val imageMeta = sampleImageMeta.copy(titles=Seq(ImageTitle("<h1>title</h1>", "nb")))
+    val imageMeta = sampleImageMeta.copy(titles=Seq(ImageTitle("<h1>title</h1>", "nob")))
     val result = validationService.validate(imageMeta)
     val exception = result.failed.get.asInstanceOf[ValidationException]
     exception.errors.length should be (1)
@@ -63,7 +63,7 @@ class ValidationServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("validate returns success if title is valid") {
-    val imageMeta = sampleImageMeta.copy(titles=Seq(ImageTitle("title", "en")))
+    val imageMeta = sampleImageMeta.copy(titles=Seq(ImageTitle("title", "eng")))
     validationService.validate(imageMeta).isSuccess should be (true)
   }
 
@@ -100,7 +100,7 @@ class ValidationServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("validate returns a validation error if tags contain html") {
-    val imageMeta = sampleImageMeta.copy(tags=Seq(ImageTag(Seq("<h1>tag</h1>"), "en")))
+    val imageMeta = sampleImageMeta.copy(tags=Seq(ImageTag(Seq("<h1>tag</h1>"), "eng")))
     val result = validationService.validate(imageMeta)
     val exception = result.failed.get.asInstanceOf[ValidationException]
     exception.errors.length should be (1)
@@ -118,12 +118,12 @@ class ValidationServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("validate returns success if tags are valid") {
-    val imageMeta = sampleImageMeta.copy(tags=Seq(ImageTag(Seq("tag"), "en")))
+    val imageMeta = sampleImageMeta.copy(tags=Seq(ImageTag(Seq("tag"), "eng")))
     validationService.validate(imageMeta).isSuccess should be (true)
   }
 
   test("validate returns a validation error if alt texts contain html") {
-    val imageMeta = sampleImageMeta.copy(alttexts=Seq(ImageAltText("<h1>alt text</h1>", "en")))
+    val imageMeta = sampleImageMeta.copy(alttexts=Seq(ImageAltText("<h1>alt text</h1>", "eng")))
     val result = validationService.validate(imageMeta)
     val exception = result.failed.get.asInstanceOf[ValidationException]
     exception.errors.length should be (1)
@@ -141,12 +141,12 @@ class ValidationServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("validate returns success if alt texts are valid") {
-    val imageMeta = sampleImageMeta.copy(alttexts=Seq(ImageAltText("alt text", "en")))
+    val imageMeta = sampleImageMeta.copy(alttexts=Seq(ImageAltText("alt text", "eng")))
     validationService.validate(imageMeta).isSuccess should be (true)
   }
 
   test("validate returns a validation error if captions contain html") {
-    val imageMeta = sampleImageMeta.copy(captions=Seq(ImageCaption("<h1>caption</h1>", "en")))
+    val imageMeta = sampleImageMeta.copy(captions=Seq(ImageCaption("<h1>caption</h1>", "eng")))
     val result = validationService.validate(imageMeta)
     val exception = result.failed.get.asInstanceOf[ValidationException]
     exception.errors.length should be (1)
@@ -164,8 +164,16 @@ class ValidationServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("validate returns success if captions are valid") {
-    val imageMeta = sampleImageMeta.copy(captions=Seq(ImageCaption("caption", "en")))
+    val imageMeta = sampleImageMeta.copy(captions=Seq(ImageCaption("caption", "eng")))
     validationService.validate(imageMeta).isSuccess should be (true)
+  }
+
+  test("languageCodeIsValid requires 3 lowercase letters") {
+    val results = for {
+      language <- Seq("", "a", "no", "enG", "ENG", "nOB", "nobb")
+      imageMeta = sampleImageMeta.copy(alttexts=Seq(ImageAltText("alt text", language)))
+    } yield (language, validationService.validate(imageMeta).isSuccess)
+    results.foreach{case (lang, success) => withClue(s"Language '$lang' should not be accepted.") { success should be (false)} }
   }
 
 }


### PR DESCRIPTION
GlobalDigitalLibraryio/issues#72

Based on https://github.com/GlobalDigitalLibraryio/image-api/pull/3, but modified as we found out that we wanted to allow only 3 lettered language codes. Currently we don't do any more validation than this and an all-lowercase check.