### PR TITLE
#62: Don't keep alive TCP-connections to AWS

### DIFF
--- a/src/main/scala/no/ndla/imageapi/ComponentRegistry.scala
+++ b/src/main/scala/no/ndla/imageapi/ComponentRegistry.scala
@@ -8,8 +8,9 @@
 
 package no.ndla.imageapi
 
+import com.amazonaws.ClientConfiguration
 import com.amazonaws.regions.Regions
-import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import no.ndla.imageapi.auth.{Role, User}
 import no.ndla.imageapi.controller._
 import no.ndla.imageapi.integration._
@@ -58,7 +59,13 @@ object ComponentRegistry
   dataSource.setMaxConnections(ImageApiProperties.MetaMaxConnections)
   dataSource.setCurrentSchema(ImageApiProperties.MetaSchema)
 
-  val amazonClient = AmazonS3ClientBuilder.standard().withRegion(Regions.EU_CENTRAL_1).build()
+  val amazonClient: AmazonS3 = AmazonS3ClientBuilder.standard()
+    .withClientConfiguration(
+      new ClientConfiguration()
+      .withTcpKeepAlive(false)
+    )
+    .withRegion(Regions.EU_CENTRAL_1)
+    .build()
 
   lazy val indexService = new IndexService
   lazy val searchService = new SearchService


### PR DESCRIPTION
GlobalDigitalLibraryio/issues#62

After putting lots of images to S3, this happened:
```
image-api] 2017-11-14 09:28:24.418 [qtp273777019-49] (505de2c7-16c1-4da6-a48c-0ed55e09b645) INFO  no.ndla.imageapi.controller.NdlaController.$anonfun$new$1#38: POST /image-api/v1/images
[image-api] 2017-11-14 09:28:44.422 [qtp273777019-49] (505de2c7-16c1-4da6-a48c-0ed55e09b645) ERROR no.ndla.imageapi.controller.NdlaController$$anonfun$1.applyOrElse#62: Error(GENERIC,Ooops. Something we didn't anticipate occurred. We have logged the error, and will look into it. But feel free to contact christergundersen@ndla.no if the error persists.,2017-11-10 14:44:25.764)
com.amazonaws.SdkClientException: Unable to execute HTTP request: Timeout waiting for connection from pool
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1038) ~[image-api.jar:0.1]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:742) ~[image-api.jar:0.1]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:716) ~[image-api.jar:0.1]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:699) ~[image-api.jar:0.1]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:667) ~[image-api.jar:0.1]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:649) ~[image-api.jar:0.1]
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:513) ~[image-api.jar:0.1]
	at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:4194) ~[image-api.jar:0.1]
	at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:4141) ~[image-api.jar:0.1]
	at com.amazonaws.services.s3.AmazonS3Client.putObject(AmazonS3Client.java:1723) ~[image-api.jar:0.1]
	at no.ndla.imageapi.service.ImageStorageService$AmazonImageStorageService.$anonfun$uploadFromStream$1(ImageStorageService.scala:50) ~[image-api.jar:0.1]
	at scala.util.Try$.apply(Try.scala:209) ~[image-api.jar:0.1]
	at no.ndla.imageapi.service.ImageStorageService$AmazonImageStorageService.uploadFromStream(ImageStorageService.scala:50) ~[image-api.jar:0.1]
	at no.ndla.imageapi.service.WriteService$WriteService.uploadImage(WriteService.scala:68) ~[image-api.jar:0.1]
	at no.ndla.imageapi.service.WriteService$WriteService.storeNewImage(WriteService.scala:27) ~[image-api.jar:0.1]
	at no.ndla.imageapi.controller.ImageController$ImageController.$anonfun$new$4(ImageController.scala:160) ~[image-api.jar:0.1]
	at org.scalatra.ScalatraBase.liftAction(ScalatraBase.scala:287) ~[image-api.jar:0.1]
	at org.scalatra.ScalatraBase.$anonfun$invoke$1(ScalatraBase.scala:281) ~[image-api.jar:0.1]
	at org.scalatra.ApiFormats.withRouteMultiParams(ApiFormats.scala:188) ~[image-api.jar:0.1]
	at org.scalatra.ApiFormats.withRouteMultiParams$(ApiFormats.scala:174) ~[image-api.jar:0.1]
	at no.ndla.imageapi.controller.NdlaController.withRouteMultiParams(NdlaController.scala:29) ~[image-api.jar:0.1]
	at org.scalatra.ScalatraBase.invoke(ScalatraBase.scala:280) ~[image-api.jar:0.1]
	at org.scalatra.ScalatraBase.invoke$(ScalatraBase.scala:279) ~[image-api.jar:0.1]
	at no.ndla.imageapi.controller.NdlaController.org$scalatra$json$JsonSupport$$super$invoke(NdlaController.scala:29) ~[image-api.jar:0.1]
	at org.scalatra.json.JsonSupport.$anonfun$invoke$1(JsonSupport.scala:88) ~[image-api.jar:0.1]
	at org.scalatra.ApiFormats.withRouteMultiParams(ApiFormats.scala:188) ~[image-api.jar:0.1]
	at org.scalatra.ApiFormats.withRouteMultiParams$(ApiFormats.scala:174) ~[image-api.jar:0.1]
	at no.ndla.imageapi.controller.NdlaController.withRouteMultiParams(NdlaController.scala:29) ~[image-api.jar:0.1]
	at org.scalatra.json.JsonSupport.invoke(JsonSupport.scala:82) ~[image-api.jar:0.1]
	at org.scalatra.json.JsonSupport.invoke$(JsonSupport.scala:81) ~[image-api.jar:0.1]
	at no.ndla.imageapi.controller.NdlaController.invoke(NdlaController.scala:29) ~[image-api.jar:0.1]
	at org.scalatra.ScalatraBase.$anonfun$runRoutes$3(ScalatraBase.scala:255) ~[image-api.jar:0.1]
	at scala.Option.flatMap(Option.scala:171) ~[image-api.jar:0.1]
	at org.scalatra.ScalatraBase.$anonfun$runRoutes$1(ScalatraBase.scala:253) ~[image-api.jar:0.1]
	at scala.collection.immutable.Stream.flatMap(Stream.scala:486) ~[image-api.jar:0.1]
	at org.scalatra.ScalatraBase.runRoutes(ScalatraBase.scala:252) ~[image-api.jar:0.1]
	at org.scalatra.ScalatraBase.runRoutes$(ScalatraBase.scala:250) ~[image-api.jar:0.1]
	at no.ndla.imageapi.controller.NdlaController.runRoutes(NdlaController.scala:29) ~[image-api.jar:0.1]
	at org.scalatra.ScalatraBase.runActions$1(ScalatraBase.scala:175) ~[image-api.jar:0.1]
	at org.scalatra.ScalatraBase.$anonfun$executeRoutes$6(ScalatraBase.scala:187) ~[image-api.jar:0.1]
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12) ~[image-api.jar:0.1]
	at org.scalatra.ScalatraBase.cradleHalt(ScalatraBase.scala:205) ~[image-api.jar:0.1]
	at org.scalatra.ScalatraBase.executeRoutes(ScalatraBase.scala:187) ~[image-api.jar:0.1]
	at org.scalatra.ScalatraBase.executeRoutes$(ScalatraBase.scala:153) ~[image-api.jar:0.1]
	at no.ndla.imageapi.controller.NdlaController.executeRoutes(NdlaController.scala:29) ~[image-api.jar:0.1]
	at org.scalatra.ScalatraBase.$anonfun$handle$1(ScalatraBase.scala:126) ~[image-api.jar:0.1]
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12) ~[image-api.jar:0.1]
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:58) ~[image-api.jar:0.1]
	at org.scalatra.DynamicScope.withResponse(DynamicScope.scala:79) ~[image-api.jar:0.1]
	at org.scalatra.DynamicScope.withResponse$(DynamicScope.scala:77) ~[image-api.jar:0.1]
	at no.ndla.imageapi.controller.NdlaController.withResponse(NdlaController.scala:29) ~[image-api.jar:0.1]
	at org.scalatra.DynamicScope.$anonfun$withRequestResponse$1(DynamicScope.scala:59) ~[image-api.jar:0.1]
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:58) ~[image-api.jar:0.1]
	at org.scalatra.DynamicScope.withRequest(DynamicScope.scala:70) ~[image-api.jar:0.1]
	at org.scalatra.DynamicScope.withRequest$(DynamicScope.scala:68) ~[image-api.jar:0.1]
	at no.ndla.imageapi.controller.NdlaController.withRequest(NdlaController.scala:29) ~[image-api.jar:0.1]
	at org.scalatra.DynamicScope.withRequestResponse(DynamicScope.scala:58) ~[image-api.jar:0.1]
	at org.scalatra.DynamicScope.withRequestResponse$(DynamicScope.scala:56) ~[image-api.jar:0.1]
	at no.ndla.imageapi.controller.NdlaController.withRequestResponse(NdlaController.scala:29) ~[image-api.jar:0.1]
	at org.scalatra.ScalatraBase.handle(ScalatraBase.scala:126) ~[image-api.jar:0.1]
	at org.scalatra.ScalatraBase.handle$(ScalatraBase.scala:122) ~[image-api.jar:0.1]
	at no.ndla.imageapi.controller.NdlaController.org$scalatra$servlet$ServletBase$$super$handle(NdlaController.scala:29) ~[image-api.jar:0.1]
	at org.scalatra.servlet.ServletBase.handle(ServletBase.scala:53) ~[image-api.jar:0.1]
	at org.scalatra.servlet.ServletBase.handle$(ServletBase.scala:46) ~[image-api.jar:0.1]
	at no.ndla.imageapi.controller.ImageController$ImageController.org$scalatra$CorsSupport$$super$handle(ImageController.scala:32) ~[image-api.jar:0.1]
	at org.scalatra.CorsSupport.$anonfun$handle$1(CORSSupport.scala:226) ~[image-api.jar:0.1]
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12) ~[image-api.jar:0.1]
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:58) ~[image-api.jar:0.1]
	at org.scalatra.DynamicScope.withResponse(DynamicScope.scala:79) ~[image-api.jar:0.1]
	at org.scalatra.DynamicScope.withResponse$(DynamicScope.scala:77) ~[image-api.jar:0.1]
	at no.ndla.imageapi.controller.NdlaController.withResponse(NdlaController.scala:29) ~[image-api.jar:0.1]
	at org.scalatra.DynamicScope.$anonfun$withRequestResponse$1(DynamicScope.scala:59) ~[image-api.jar:0.1]
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:58) [image-api.jar:0.1]
	at org.scalatra.DynamicScope.withRequest(DynamicScope.scala:70) [image-api.jar:0.1]
	at org.scalatra.DynamicScope.withRequest$(DynamicScope.scala:68) [image-api.jar:0.1]
	at no.ndla.imageapi.controller.NdlaController.withRequest(NdlaController.scala:29) [image-api.jar:0.1]
	at org.scalatra.DynamicScope.withRequestResponse(DynamicScope.scala:58) [image-api.jar:0.1]
	at org.scalatra.DynamicScope.withRequestResponse$(DynamicScope.scala:56) [image-api.jar:0.1]
	at no.ndla.imageapi.controller.NdlaController.withRequestResponse(NdlaController.scala:29) [image-api.jar:0.1]
	at org.scalatra.CorsSupport.handle(CORSSupport.scala:214) [image-api.jar:0.1]
	at org.scalatra.CorsSupport.handle$(CORSSupport.scala:211) [image-api.jar:0.1]
	at no.ndla.imageapi.controller.ImageController$ImageController.org$scalatra$servlet$FileUploadSupport$$super$handle(ImageController.scala:32) [image-api.jar:0.1]
	at org.scalatra.servlet.FileUploadSupport.handle(FileUploadSupport.scala:94) [image-api.jar:0.1]
	at org.scalatra.servlet.FileUploadSupport.handle$(FileUploadSupport.scala:79) [image-api.jar:0.1]
	at no.ndla.imageapi.controller.ImageController$ImageController.handle(ImageController.scala:32) [image-api.jar:0.1]
	at org.scalatra.ScalatraServlet.service(ScalatraServlet.scala:61) [image-api.jar:0.1]
	at org.scalatra.ScalatraServlet.service$(ScalatraServlet.scala:60) [image-api.jar:0.1]
	at no.ndla.imageapi.controller.NdlaController.service(NdlaController.scala:29) [image-api.jar:0.1]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790) [image-api.jar:0.1]
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:808) [image-api.jar:0.1]
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:587) [image-api.jar:0.1]
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1127) [image-api.jar:0.1]
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:515) [image-api.jar:0.1]
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1061) [image-api.jar:0.1]
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141) [image-api.jar:0.1]
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97) [image-api.jar:0.1]
	at org.eclipse.jetty.server.Server.handle(Server.java:497) [image-api.jar:0.1]
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:310) [image-api.jar:0.1]
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:257) [image-api.jar:0.1]
	at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:540) [image-api.jar:0.1]
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:635) [image-api.jar:0.1]
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:555) [image-api.jar:0.1]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_131]
Caused by: org.apache.http.conn.ConnectionPoolTimeoutException: Timeout waiting for connection from pool
	at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.leaseConnection(PoolingHttpClientConnectionManager.java:286) ~[image-api.jar:0.1]
	at org.apache.http.impl.conn.PoolingHttpClientConnectionManager$1.get(PoolingHttpClientConnectionManager.java:263) ~[image-api.jar:0.1]
	at sun.reflect.GeneratedMethodAccessor26.invoke(Unknown Source) ~[?:?]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_131]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_131]
	at com.amazonaws.http.conn.ClientConnectionRequestFactory$Handler.invoke(ClientConnectionRequestFactory.java:70) ~[image-api.jar:0.1]
	at com.amazonaws.http.conn.$Proxy29.get(Unknown Source) ~[?:0.1]
	at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:190) ~[image-api.jar:0.1]
	at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:184) ~[image-api.jar:0.1]
	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:184) ~[image-api.jar:0.1]
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:82) ~[image-api.jar:0.1]
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:55) ~[image-api.jar:0.1]
	at com.amazonaws.http.apache.client.impl.SdkHttpClient.execute(SdkHttpClient.java:72) ~[image-api.jar:0.1]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1181) ~[image-api.jar:0.1]
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1030) ~[image-api.jar:0.1]
	... 102 more
```
_Not_ keeping TCP connections alive should prevent this from happening.