### PR TITLE
#62: Close stream after use

### DIFF
--- a/src/main/scala/no/ndla/imageapi/ComponentRegistry.scala
+++ b/src/main/scala/no/ndla/imageapi/ComponentRegistry.scala
@@ -60,10 +60,6 @@ object ComponentRegistry
   dataSource.setCurrentSchema(ImageApiProperties.MetaSchema)
 
   val amazonClient: AmazonS3 = AmazonS3ClientBuilder.standard()
-    .withClientConfiguration(
-      new ClientConfiguration()
-      .withTcpKeepAlive(false)
-    )
     .withRegion(Regions.EU_CENTRAL_1)
     .build()
 


### PR DESCRIPTION
GlobalDigitalLibraryio/issues#62

_Looks_ like the problem with `com.amazonaws.SdkClientException: Unable to execute HTTP request: Timeout waiting for connection from pool` has to do with not closing streams while uploading files to S3.

This error has been hard to reproduce in a deterministic way, so I put a WIP label on this PR for now, as I'm not entirely sure that I've identified the problem, nor that this is the solution.