### PR TITLE
#363: Upgraded to v0.8 of mapping to support more licenses

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ lazy val image_api = (project in file(".")).
     scalacOptions := Seq("-target:jvm-1.8", "-unchecked", "-deprecation", "-feature"),
     libraryDependencies ++= Seq(
       "gdl" %% "network" % "0.7",
-      "ndla" %% "mapping" % "0.7",
+      "ndla" %% "mapping" % "0.8",
       "gdl" %% "language" % "0.5",
       "joda-time" % "joda-time" % "2.8.2",
       "org.scalatra" %% "scalatra" % Scalatraversion,


### PR DESCRIPTION
In order to clean up licenses, the image-api need to support the licenses. This bump in mapping-library adds the needed licenses.