### PR TITLE
#348: Don't repeat imageUrl and make sure leading '/'

### DIFF
--- a/src/main/scala/no/ndla/imageapi/controller/ImageControllerV2.scala
+++ b/src/main/scala/no/ndla/imageapi/controller/ImageControllerV2.scala
@@ -183,7 +183,6 @@ trait ImageControllerV2 {
         notes "Insert or update stored parameters for an image"
         parameters(
         asHeaderParam[Option[String]](correlationId),
-        asPathParam[String](imageUrl),
         bodyParam[StoredParameters]
       )
         responseMessages(response404, response400, response500))

--- a/src/main/scala/no/ndla/imageapi/controller/ImageControllerV2.scala
+++ b/src/main/scala/no/ndla/imageapi/controller/ImageControllerV2.scala
@@ -188,12 +188,11 @@ trait ImageControllerV2 {
       )
         responseMessages(response404, response400, response500))
 
-    post("/stored-parameters/:image_url", operation(postStoredParameters)) {
+    post("/stored-parameters", operation(postStoredParameters)) {
       authUser.assertHasId()
       authRole.assertHasRole(RoleWithWriteAccess)
-      val imageUrl = "/" + params("image_url")
       Try(extract[StoredParameters](request.body)).toOption match {
-        case Some(parameters) => writeService.storeParameters(imageUrl, parameters)
+        case Some(parameters) => writeService.storeParameters(parameters)
         case None => throw new ValidationException(errors = Seq(ValidationMessage("body", "Invalid body for parameters")))
       }
     }

--- a/src/main/scala/no/ndla/imageapi/repository/ImageRepository.scala
+++ b/src/main/scala/no/ndla/imageapi/repository/ImageRepository.scala
@@ -25,10 +25,10 @@ trait ImageRepository {
 
   class ImageRepository extends LazyLogging {
 
-    def insertOrUpdateStoredParameters(imageUrl: String, parameters: StoredParameters)(implicit session: DBSession = AutoSession): StoredParameters = {
-      getStoredParametersFor(imageUrl, parameters.forRatio) match {
-        case Some(_) => updateStoredParameters(imageUrl, parameters)
-        case None => insertStoredParameters(imageUrl, parameters)
+    def insertOrUpdateStoredParameters(parameters: StoredParameters)(implicit session: DBSession = AutoSession): StoredParameters = {
+      getStoredParametersFor(parameters.imageUrl, parameters.forRatio) match {
+        case Some(_) => updateStoredParameters(parameters.imageUrl, parameters)
+        case None => insertStoredParameters(parameters.imageUrl, parameters)
       }
     }
 

--- a/src/main/scala/no/ndla/imageapi/service/ValidationService.scala
+++ b/src/main/scala/no/ndla/imageapi/service/ValidationService.scala
@@ -21,6 +21,8 @@ trait ValidationService {
       val r = parameters.rawImageQueryParameters
       if (!Seq(r.cropStartX, r.cropStartY, r.cropEndX, r.cropEndY, r.focalX, r.focalY).flatten.forall(validPercentage)) {
         Some(ValidationMessage("rawImageQueryParameters", "Percentage values must be in the range [0, 100]"))
+      } else if (!parameters.imageUrl.startsWith("/")) {
+        Some(ValidationMessage("imageUrl", "Image URL has to start with a '/'"))
       } else {
         None
       }

--- a/src/main/scala/no/ndla/imageapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/imageapi/service/WriteService.scala
@@ -19,10 +19,10 @@ trait WriteService {
   val writeService: WriteService
 
   class WriteService extends LazyLogging {
-    def storeParameters(imageUrl: String, parameters: StoredParameters): Try[StoredParameters] = {
+    def storeParameters(parameters: StoredParameters): Try[StoredParameters] = {
       validationService.validateStoredParameters(parameters) match {
         case Some(validationMessage) => Failure(new ValidationException(errors = Seq(validationMessage)))
-        case None => Try(imageRepository.insertOrUpdateStoredParameters(imageUrl, parameters))
+        case None => Try(imageRepository.insertOrUpdateStoredParameters(parameters))
       }
     }
 

--- a/src/test/scala/no/ndla/imageapi/controller/ImageControllerV2Test.scala
+++ b/src/test/scala/no/ndla/imageapi/controller/ImageControllerV2Test.scala
@@ -253,26 +253,26 @@ class ImageControllerV2Test extends UnitSuite with ScalatraSuite with TestEnviro
     }
   }
 
-  test("That POST /stored-parameters/123abc.jpg without acceptable body is rejected") {
-    post("/stored-parameters/123abc.jpg", "{}", headers = Map("Authorization" -> authHeaderWithWriteRole)) {
+  test("That POST /stored-parameters without acceptable body is rejected") {
+    post("/stored-parameters", "{}", headers = Map("Authorization" -> authHeaderWithWriteRole)) {
       status should equal(400)
     }
   }
 
-  test("That POST /stored-parameters/123abc.jpg with acceptable body is accepted") {
-    post("/stored-parameters/123abc.jpg", """ {"imageUrl": "/123abc.jpg", "forRatio": "0.81", "rawImageQueryParameters": {"focalX": 50} } """, headers = Map("Authorization" -> authHeaderWithWriteRole)) {
+  test("That POST /stored-parameters with acceptable body is accepted") {
+    post("/stored-parameters", """ {"imageUrl": "/123abc.jpg", "forRatio": "0.81", "rawImageQueryParameters": {"focalX": 50} } """, headers = Map("Authorization" -> authHeaderWithWriteRole)) {
       status should equal(200)
     }
   }
 
-  test("That POST /stored-parameters/123abc.jpg checks authorization") {
-    post("/stored-parameters/123abc.jpg") {
+  test("That POST /stored-parameters checks authorization") {
+    post("/stored-parameters") {
       status should equal(403)
     }
-    post("/stored-parameters/123abc.jpg", headers = Map("Authorization" -> authHeaderWithoutAnyRoles)) {
+    post("/stored-parameters", headers = Map("Authorization" -> authHeaderWithoutAnyRoles)) {
       status should equal(403)
     }
-    post("/stored-parameters/123abc.jpg", headers = Map("Authorization" -> authHeaderWithWrongRole)) {
+    post("/stored-parameters", headers = Map("Authorization" -> authHeaderWithWrongRole)) {
       status should equal(403)
     }
   }

--- a/src/test/scala/no/ndla/imageapi/service/ValidationServiceTest.scala
+++ b/src/test/scala/no/ndla/imageapi/service/ValidationServiceTest.scala
@@ -147,4 +147,9 @@ class ValidationServiceTest extends UnitSuite with TestEnvironment {
     validationService.validateStoredParameters(p).isDefined should be (true)
   }
 
+  test("validate returns a validation error if imageUrl doesn't start with a '/'") {
+    val p = StoredParameters(imageUrl = "123.jpg", forRatio = "0.81", revision = Some(1), rawImageQueryParameters = RawImageQueryParameters(width = None, height = None, cropStartX = Some(10), cropStartY = Some(10), cropEndX = None, cropEndY = None, focalX = Some(50), focalY = Some(60), ratio = Some("0.81")))
+    validationService.validateStoredParameters(p).isDefined should be (true)
+  }
+
 }


### PR DESCRIPTION
GlobalDigitalLibraryio/issues#348

All our imageUrls starts with `/`, and we don't want to store imageUrls without this. And we don't need to duplicate the imageUrl in the path when POSTing.